### PR TITLE
allow console logs to have timestamps instead of offsets

### DIFF
--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -95,7 +95,11 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 	ts := d / time.Second
 	tms := (d - ts*time.Second) / time.Millisecond
 	if colored {
-		_, _ = fmt.Fprintf(sb, "% 4d.%03d \033[%d;%dm%-5s\033[0m %-20s", ts, tms, intensity, color, level, e.Message)
+		if h.Start == utc.Zero {
+			_, _ = fmt.Fprintf(sb, "%s \033[%d;%dm%-5s\033[0m %-20s", utc.Now().String(), intensity, color, level, e.Message)
+		} else {
+			_, _ = fmt.Fprintf(sb, "% 4d.%03d \033[%d;%dm%-5s\033[0m %-20s", ts, tms, intensity, color, level, e.Message)
+		}
 		//fmt.Fprintf(sb, "\033[%dm%-1s\033[0m % 4d.%03d %-20s", color, level, ts, tms, e.Message)
 	} else {
 		_, _ = fmt.Fprintf(sb, "% 4d.%03d %-5s %-20s", ts, tms, level, e.Message)

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -61,16 +61,17 @@ var Levels = [...]string{
 
 // Handler implementation.
 type Handler struct {
-	Start   utc.UTC
-	noColor bool
-	mu      sync.Mutex
-	Writer  io.Writer
+	start         utc.UTC
+	noColor       bool
+	mu            sync.Mutex
+	Writer        io.Writer
+	UseTimestamps bool
 }
 
 // New creates a new console handler.
 func New(w io.Writer) *Handler {
 	return &Handler{
-		Start:  utc.Now(),
+		start:  utc.Now(),
 		Writer: w,
 	}
 }
@@ -91,11 +92,11 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 	colored := !h.noColor
 	level := Levels[e.Level]
 
-	d := utc.Since(h.Start)
+	d := utc.Since(h.start)
 	ts := d / time.Second
 	tms := (d - ts*time.Second) / time.Millisecond
 	if colored {
-		if h.Start == utc.Zero {
+		if h.UseTimestamps {
 			_, _ = fmt.Fprintf(sb, "%s \033[%d;%dm%-5s\033[0m %-20s", utc.Now().String(), intensity, color, level, e.Message)
 		} else {
 			_, _ = fmt.Fprintf(sb, "% 4d.%03d \033[%d;%dm%-5s\033[0m %-20s", ts, tms, intensity, color, level, e.Message)

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -61,7 +61,7 @@ var Levels = [...]string{
 
 // Handler implementation.
 type Handler struct {
-	start   utc.UTC
+	Start   utc.UTC
 	noColor bool
 	mu      sync.Mutex
 	Writer  io.Writer
@@ -70,7 +70,7 @@ type Handler struct {
 // New creates a new console handler.
 func New(w io.Writer) *Handler {
 	return &Handler{
-		start:  utc.Now(),
+		Start:  utc.Now(),
 		Writer: w,
 	}
 }
@@ -91,7 +91,7 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 	colored := !h.noColor
 	level := Levels[e.Level]
 
-	d := utc.Since(h.start)
+	d := utc.Since(h.Start)
 	ts := d / time.Second
 	tms := (d - ts*time.Second) / time.Millisecond
 	if colored {

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -103,7 +103,11 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 		}
 		//fmt.Fprintf(sb, "\033[%dm%-1s\033[0m % 4d.%03d %-20s", color, level, ts, tms, e.Message)
 	} else {
-		_, _ = fmt.Fprintf(sb, "% 4d.%03d %-5s %-20s", ts, tms, level, e.Message)
+		if h.UseTimestamps {
+			_, _ = fmt.Fprintf(sb, "%s %-5s %-20s", utc.Now().String(), level, e.Message)
+		} else {
+			_, _ = fmt.Fprintf(sb, "% 4d.%03d %-5s %-20s", ts, tms, level, e.Message)
+		}
 	}
 
 	for _, field := range e.Fields {

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -65,7 +65,7 @@ type Handler struct {
 	noColor       bool
 	mu            sync.Mutex
 	Writer        io.Writer
-	UseTimestamps bool
+	useTimestamps bool
 }
 
 // New creates a new console handler.
@@ -74,6 +74,12 @@ func New(w io.Writer) *Handler {
 		start:  utc.Now(),
 		Writer: w,
 	}
+}
+
+func (h *Handler) UseTimestamps(use bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.useTimestamps = use
 }
 
 func (h *Handler) WithColor(colored bool) {

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -102,14 +102,14 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 	ts := d / time.Second
 	tms := (d - ts*time.Second) / time.Millisecond
 	if colored {
-		if h.UseTimestamps {
+		if h.useTimestamps {
 			_, _ = fmt.Fprintf(sb, "%s \033[%d;%dm%-5s\033[0m %-20s", utc.Now().String(), intensity, color, level, e.Message)
 		} else {
 			_, _ = fmt.Fprintf(sb, "% 4d.%03d \033[%d;%dm%-5s\033[0m %-20s", ts, tms, intensity, color, level, e.Message)
 		}
 		//fmt.Fprintf(sb, "\033[%dm%-1s\033[0m % 4d.%03d %-20s", color, level, ts, tms, e.Message)
 	} else {
-		if h.UseTimestamps {
+		if h.useTimestamps {
 			_, _ = fmt.Fprintf(sb, "%s %-5s %-20s", utc.Now().String(), level, e.Message)
 		} else {
 			_, _ = fmt.Fprintf(sb, "% 4d.%03d %-5s %-20s", ts, tms, level, e.Message)

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -76,6 +76,11 @@ func New(w io.Writer) *Handler {
 	}
 }
 
+// UseTimestamps enables or disables timestamps instead of offsets in the log output.
+// Usage:
+//     if lh, ok := log.Handler().(*console.Handler); ok {
+//         lh.UseTimestamps(true)
+//     }
 func (h *Handler) UseTimestamps(use bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/handlers/console/console.go
+++ b/handlers/console/console.go
@@ -77,10 +77,6 @@ func New(w io.Writer) *Handler {
 }
 
 // UseTimestamps enables or disables timestamps instead of offsets in the log output.
-// Usage:
-//     if lh, ok := log.Handler().(*console.Handler); ok {
-//         lh.UseTimestamps(true)
-//     }
 func (h *Handler) UseTimestamps(use bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/handlers/console/console_test.go
+++ b/handlers/console/console_test.go
@@ -4,36 +4,90 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/eluv-io/log-go"
 	"github.com/eluv-io/log-go/handlers/console"
 	"github.com/eluv-io/utc-go"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHandler(t *testing.T) {
 	defer utc.MockNow(utc.UnixMilli(0))()
 
-	fls := false
-	lg := log.New(&log.Config{
-		Level:       "trace",
-		Handler:     "console",
-		GoRoutineID: &fls,
-	})
+	tests := []struct {
+		name  string
+		adapt func(h *console.Handler)
+		want  string
+	}{
+		{
+			name:  "default: offset, color",
+			adapt: func(h *console.Handler) {},
+			want: "" +
+				"   0.000 \033[0;37mTRCE \033[0m trace message        field1=\033[0;37mvalue1\033[0m field2=\033[0;37mvalue2\033[0m\n" +
+				"   0.000 \033[0;33mDBG  \033[0m debug message        field1=\033[0;33mvalue1\033[0m field2=\033[0;33mvalue2\033[0m\n" +
+				"   0.000 \033[0;34m     \033[0m info message         field1=\033[0;34mvalue1\033[0m field2=\033[0;34mvalue2\033[0m\n" +
+				"   0.000 \033[0;35mWARN \033[0m warn message         field1=\033[0;35mvalue1\033[0m field2=\033[0;35mvalue2\033[0m\n" +
+				"   0.000 \033[0;31mERR! \033[0m error message        field1=\033[0;31mvalue1\033[0m field2=\033[0;31mvalue2\033[0m\n",
+		},
+		{
+			name: "offset, no color",
+			adapt: func(h *console.Handler) {
+				h.WithColor(false)
+			},
+			want: "" +
+				"   0.000 TRCE  trace message        field1=value1 field2=value2\n" +
+				"   0.000 DBG   debug message        field1=value1 field2=value2\n" +
+				"   0.000       info message         field1=value1 field2=value2\n" +
+				"   0.000 WARN  warn message         field1=value1 field2=value2\n" +
+				"   0.000 ERR!  error message        field1=value1 field2=value2\n",
+		},
+		{
+			name: "timestamp, color",
+			adapt: func(h *console.Handler) {
+				h.WithTimestamps(true)
+			},
+			want: "" +
+				"1970-01-01T00:00:00.000Z \033[0;37mTRCE \033[0m trace message        field1=\033[0;37mvalue1\033[0m field2=\033[0;37mvalue2\033[0m\n" +
+				"1970-01-01T00:00:00.000Z \033[0;33mDBG  \033[0m debug message        field1=\033[0;33mvalue1\033[0m field2=\033[0;33mvalue2\033[0m\n" +
+				"1970-01-01T00:00:00.000Z \033[0;34m     \033[0m info message         field1=\033[0;34mvalue1\033[0m field2=\033[0;34mvalue2\033[0m\n" +
+				"1970-01-01T00:00:00.000Z \033[0;35mWARN \033[0m warn message         field1=\033[0;35mvalue1\033[0m field2=\033[0;35mvalue2\033[0m\n" +
+				"1970-01-01T00:00:00.000Z \033[0;31mERR! \033[0m error message        field1=\033[0;31mvalue1\033[0m field2=\033[0;31mvalue2\033[0m\n",
+		},
+		{
+			name: "timestamp, no color",
+			adapt: func(h *console.Handler) {
+				h.WithTimestamps(true).WithColor(false)
+			},
+			want: "" +
+				"1970-01-01T00:00:00.000Z TRCE  trace message        field1=value1 field2=value2\n" +
+				"1970-01-01T00:00:00.000Z DBG   debug message        field1=value1 field2=value2\n" +
+				"1970-01-01T00:00:00.000Z       info message         field1=value1 field2=value2\n" +
+				"1970-01-01T00:00:00.000Z WARN  warn message         field1=value1 field2=value2\n" +
+				"1970-01-01T00:00:00.000Z ERR!  error message        field1=value1 field2=value2\n",
+		},
+	}
 
-	buf := &bytes.Buffer{}
-	lg.Handler().(*console.Handler).Writer = buf
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fls := false
+			lg := log.New(&log.Config{
+				Level:       "trace",
+				Handler:     "console",
+				GoRoutineID: &fls,
+			})
 
-	lg.Trace("trace message", "field1", "value1", "field2", "value2")
-	lg.Debug("debug message", "field1", "value1", "field2", "value2")
-	lg.Info("info message", "field1", "value1", "field2", "value2")
-	lg.Warn("warn message", "field1", "value1", "field2", "value2")
-	lg.Error("error message", "field1", "value1", "field2", "value2")
+			buf := &bytes.Buffer{}
+			handler := lg.Handler().(*console.Handler)
+			handler.Writer = buf
+			test.adapt(handler)
 
-	exp := "" +
-		"   0.000 \033[0;37mTRCE \033[0m trace message        field1=\033[0;37mvalue1\033[0m field2=\033[0;37mvalue2\033[0m\n" +
-		"   0.000 \033[0;33mDBG  \033[0m debug message        field1=\033[0;33mvalue1\033[0m field2=\033[0;33mvalue2\033[0m\n" +
-		"   0.000 \033[0;34m     \033[0m info message         field1=\033[0;34mvalue1\033[0m field2=\033[0;34mvalue2\033[0m\n" +
-		"   0.000 \033[0;35mWARN \033[0m warn message         field1=\033[0;35mvalue1\033[0m field2=\033[0;35mvalue2\033[0m\n" +
-		"   0.000 \033[0;31mERR! \033[0m error message        field1=\033[0;31mvalue1\033[0m field2=\033[0;31mvalue2\033[0m\n"
-	require.Equal(t, exp, buf.String())
+			lg.Trace("trace message", "field1", "value1", "field2", "value2")
+			lg.Debug("debug message", "field1", "value1", "field2", "value2")
+			lg.Info("info message", "field1", "value1", "field2", "value2")
+			lg.Warn("warn message", "field1", "value1", "field2", "value2")
+			lg.Error("error message", "field1", "value1", "field2", "value2")
+
+			require.Equal(t, test.want, buf.String())
+		})
+	}
 }


### PR DESCRIPTION
https://github.com/eluv-io/log-go/issues/5

we want timestamps like such:
```
2022-12-20T01:22:51.423Z INFO  DoNotify                  logger=/eluvio/pushservice userId=0x3C48a30Fc0085E63dB0D88d46551435B7ba5fD37 tenantId=itenYQbgk66W1BFEqWr95xPmHZEjmdF type=LISTING_SOLD doPush=true
```

instead of 
```
95.333     DoNotify       userId=0x3c48a30fc0085e63db0d88d46551435b7ba5fd37 tenantId=itenYQbgk66W1BFEqWr95xPmHZEjmdF type=TOKEN_UPDATED doPush=true
```

as option for "console" colorized output
