### PR TITLE
add gid to front of fields list

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -143,15 +143,18 @@ func (l *logger) Fatal(msg string, fields ...interface{}) {
 }
 
 func (l *logger) fields(args []interface{}) []interface{} {
-	a := make([]interface{}, 0, len(args)+4)
-
-	if l.config.GoRoutineID != nil && *l.config.GoRoutineID {
-		a = append(a, "gid", goID())
+	addGID := l.config.GoRoutineID != nil && *l.config.GoRoutineID
+	addCaller := l.config.Caller != nil && *l.config.Caller
+	if !addGID && !addCaller {
+		return args
 	}
 
+	a := make([]interface{}, 0, len(args)+4)
+	if addGID {
+		a = append(a, "gid", goID())
+	}
 	a = append(a, args...)
-
-	if l.config.Caller != nil && *l.config.Caller {
+	if addCaller {
 		a = append(a, "caller", caller(2))
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -143,15 +143,19 @@ func (l *logger) Fatal(msg string, fields ...interface{}) {
 }
 
 func (l *logger) fields(args []interface{}) []interface{} {
+	a := make([]interface{}, 0, len(args)+4)
+
 	if l.config.GoRoutineID != nil && *l.config.GoRoutineID {
-		args = append(args, "gid", goID())
+		a = append(a, "gid", goID())
 	}
+
+	a = append(a, args...)
 
 	if l.config.Caller != nil && *l.config.Caller {
-		args = append(args, "caller", caller(2))
+		a = append(a, "caller", caller(2))
 	}
 
-	return args
+	return a
 }
 
 // goID returns the goroutine id of current goroutine

--- a/sample/log_sample.go
+++ b/sample/log_sample.go
@@ -14,11 +14,11 @@ import (
 // the package's principle go source file.
 //
 // The package name serves two purposes:
-// 1. It is added to each log entry as a field called "logger". This allows to
-//    determine easily which part of the code (package) has generated the log
-//    entry.
-// 2. Logging can be configured separately for each named log instance, i.e.
-//    for each package if this convention is followed strictly.
+//  1. It is added to each log entry as a field called "logger". This allows to
+//     determine easily which part of the code (package) has generated the log
+//     entry.
+//  2. Logging can be configured separately for each named log instance, i.e.
+//     for each package if this convention is followed strictly.
 var log = elog.Get("/eluvio/log/sample")
 
 func createAccount(ID string, name string) (interface{}, error) {


### PR DESCRIPTION
Changes log entries so that the `gid` field (when applicable) is listed in the beginning (after the `logger` field, if applicable)

This may be desirable for cases in which the `gid` field is useful and at least one field consists of data with multiple lines

Consider the following log entry
```
2024-10-07T18:02:24.836Z INFO  REQUEST                   logger=/http-req raw=GET / HTTP/1.1
Host: 10.10.10.10:1001
Accept-Encoding: gzip
User-Agent: Go-http-client/1.1

 client_ip=1.1.1.1 referrer= request_id=fb6ecda3-bfb7-4abd-8f0c-534099c575eb gid=3676355
```
Performing a `grep` for `REQUEST` would only produce the first line of the log entry, thereby omitting the `gid` field, unless `grep` is explicitly instructed to emit more lines