### PR TITLE
fix propagation of log level in hierarchical loggers

### DIFF
--- a/log.go
+++ b/log.go
@@ -202,6 +202,7 @@ func (l *Log) getLogRoot() *logRoot {
 func (l *Log) setLogLevel(level apex.Level) {
 	setLevel := func(logCopy *logger) {
 		logCopy.logger().Level = level
+		logCopy.config.Level = level.String()
 	}
 	logName := l.get().name
 

--- a/log_impl.go
+++ b/log_impl.go
@@ -137,12 +137,13 @@ func (r *logRoot) Get(path string) *Log {
 		if logFound {
 			log = l
 			logPath = p
+			conf = *l.get().config
 		}
 		if c, configFound := r.defConfig.Named[p]; configFound {
-			mergeConfig(c, &conf)
 			if !logFound {
 				// there is a config at this level, but no log yet.
 				// copy the merged configuration and create a new log from it
+				mergeConfig(c, &conf)
 				cc := conf
 				log = newLog(&cc, defaultFields(&cc, p), log)
 				r.named[p] = log

--- a/log_test.go
+++ b/log_test.go
@@ -302,8 +302,8 @@ func TestSetLevelBasic(t *testing.T) {
 
 }
 
-// TestSetLevel test that changing the level in the hierarchy works and does not
-// affect fields nor other logs located upper in the hierarchy.
+// TestSetLevel verifies that changing the level in the hierarchy works and does not
+// affect fields nor other logs located higher up in the hierarchy.
 func TestSetLevel(t *testing.T) {
 	gid := true
 	c := &log.Config{


### PR DESCRIPTION
when the log level is set programmatically on a given logger, it should propagate to all descendent loggers