### PR TITLE
Expose rotation of underlying log

### DIFF
--- a/log.go
+++ b/log.go
@@ -156,6 +156,15 @@ func (l *Log) Level() string {
 	return l.get().logger().Level.String()
 }
 
+// Rotate rotates the file underpinning the log, if one exists
+func (l *Log) Rotate() error {
+	lj := l.get().lumberjack
+	if lj != nil {
+		return lj.Rotate()
+	}
+	return nil
+}
+
 // SetLevel sets the log level according to the given string.
 func (l *Log) SetLevel(level string) {
 	lvl, err := apex.ParseLevel(level)


### PR DESCRIPTION
It would be nice to have an admin API on qfab that allows rotating the log, which would make grepping for errors in a successive run more possible.

The way I have this written, it will rotate the log (or named log) depending on which logger it is called. It is a no-op if not writing to a file.