### PR TITLE
add log throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ This obviously only needs to be done once at application startup. The configurat
 See [the log configuration sample](sample/config/log_config_sample.go)
 
 
-#### Log Handlers
+### Log Handlers
 
 The following log handlers are available:
 
-##### text
+#### text
 
 A handler for text-based log files:
 
@@ -123,7 +123,7 @@ A handler for text-based log files:
 2018-03-02T15:23:04.317Z INFO  account created           account_id=456789 account_name=Another Test Account logger=/eluvio/log/sample
 ```
 
-##### console
+#### console
 
 A handler for output to the terminal with coloring:
 
@@ -135,7 +135,7 @@ A handler for output to the terminal with coloring:
    1.565 INFO  account created           account_id=456789 account_name=Another Test Account logger=/eluvio/log/sample
 ```
 
-##### json
+#### json
 
 A handler emitting json objects:
 
@@ -198,11 +198,11 @@ And pretty printed:
 }
 ```
 
-##### discard
+#### discard
 
 A handler that discards all output.
 
-#### Logging to Files
+### Logging to Files
 
 In order to write logs to a file, with automatic roll-over based on size and/or time, configure it accordingly:
 
@@ -222,4 +222,27 @@ In order to write logs to a file, with automatic roll-over based on size and/or 
 ```
 
 File logging is implemented by the 3rd-party library [lumberjack](https://github.com/natefinch/lumberjack#type-logger). See their documentation for an explanation of all configuration parameters.
+
+### Log Throttling
+
+Certain situations might require throttling the output of log messages in order to prevent log pollution. This is especially true for log statements in tight loops with uncontrollable frequency, for example when the recurrence is mandated by a configuration option. Throttling can be achieved by using the `Throttle` function:
+
+```go 
+for {
+	...
+	log.Throttle("connect").Debug("failed to connect", "error", error, "attempt", attempt)
+	...
+}
+```
+
+The `Throttle` function expects a throttling key as first argument ("connect" in the example above) that is used to identify "similar" messages that may be eliminated if occurring multiple times during the throttle period. The throttle period is 5 seconds by default, but may be configured with an optional second argument:
+
+```go 
+authLog := log.Throttle("authenticate", time.Second)
+for {
+	...
+	authLog.Debug("failed to authenticate", "error", error)
+    ...
+}
+```
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Certain situations might require throttling the output of log messages in order 
 ```go 
 for {
 	...
-	log.Throttle("connect").Debug("failed to connect", "error", error, "attempt", attempt)
+	log.Throttle("connect").Debug("failed to connect", "error", err, "attempt", attempt)
 	...
 }
 ```
@@ -241,7 +241,7 @@ The `Throttle` function expects a throttling key as first argument ("connect" in
 authLog := log.Throttle("authenticate", time.Second)
 for {
 	...
-	authLog.Debug("failed to authenticate", "error", error)
+	authLog.Debug("failed to authenticate", "error", err)
     ...
 }
 ```

--- a/handlers/raw/raw_test.go
+++ b/handlers/raw/raw_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eluv-io/utc-go"
 )
 
-func ExampleHandler() {
+func Example_rawHandler() {
 	defer utc.MockNow(utc.UnixMilli(0))()
 
 	fls := false

--- a/handlers/text/text_test.go
+++ b/handlers/text/text_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/eluv-io/utc-go"
 )
 
-func ExampleHandler() {
+func Example_textHandler() {
 	defer utc.MockNow(utc.UnixMilli(0))()
 
 	fls := false

--- a/log_examples_test.go
+++ b/log_examples_test.go
@@ -1,0 +1,33 @@
+package log_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/eluv-io/log-go"
+	"github.com/eluv-io/utc-go"
+)
+
+func ExampleLog_throttle() {
+	now := utc.UnixMilli(0)
+	defer utc.MockNowFn(func() utc.UTC { return now })()
+
+	fls := false
+	logger := log.New(
+		&log.Config{
+			Handler:     "text",
+			GoRoutineID: &fls,
+		})
+
+	for i := 1; i < 25; i++ {
+		err := errors.New("connect error")
+		logger.Throttle("connect", 100*time.Millisecond).Warn("failed to connect", err, "attempt", i)
+		now = now.Add(10 * time.Millisecond)
+	}
+
+	// Output:
+	//
+	// 1970-01-01T00:00:00.000Z WARN  failed to connect         attempt=1 error=connect error
+	// 1970-01-01T00:00:00.100Z WARN  failed to connect         attempt=11 suppressed=9 throttle_period=100ms error=connect error
+	// 1970-01-01T00:00:00.200Z WARN  failed to connect         attempt=21 suppressed=9 throttle_period=100ms error=connect error
+}

--- a/log_impl.go
+++ b/log_impl.go
@@ -219,7 +219,7 @@ func newLog(c *Config, fields *apex.Fields, parent *Log) *Log {
 
 	if par != nil && par.config.Handler == c.Handler && reflect.DeepEqual(par.config.File, file) {
 		// re-use the parent's handler if of same type
-		handler = par.logger().Handler
+		handler = par.logger.Handler
 	} else {
 		metrics().InstanceCreated()
 		if file != nil {
@@ -258,6 +258,7 @@ func newLog(c *Config, fields *apex.Fields, parent *Log) *Log {
 	ret := &Log{}
 	ret.lw.Store(&logger{
 		log:        log,
+		logger:     apexLogger,
 		name:       name,
 		config:     c,
 		lumberjack: ljack,

--- a/logs.go
+++ b/logs.go
@@ -1,5 +1,7 @@
 package log
 
+import "time"
+
 // SetDefault sets the default configuration and creates the default log based on that configuration.
 func SetDefault(c *Config) {
 	getLogRoot().setDefault(c)
@@ -81,4 +83,16 @@ func IsError() bool {
 // IsFatal returns true if the logger logs in Fatal level.
 func IsFatal() bool {
 	return def().IsFatal()
+}
+
+// Throttle returns a decorator of this log that limits the number of log messages emitted per period. The decorator is
+// tied to the given throttle key - different keys result in separate instances. The decorator logs the first message
+// and suppresses all subsequent messages that are logged within the provided period (5 seconds by default). The first
+// message in the new period is logged again, with an indication of the number of entries that were suppressed.
+//
+//	1970-01-01T00:00:00.000Z WARN  failed to connect         attempt=1 error=connect error
+//	1970-01-01T00:00:01.000Z WARN  failed to connect         attempt=11 suppressed=9 throttle_period=1s error=connect error
+//	1970-01-01T00:00:02.000Z WARN  failed to connect         attempt=21 suppressed=9 throttle_period=1s error=connect error
+func Throttle(key string, period ...time.Duration) Throttled {
+	return def().Throttle(key, period...)
 }

--- a/throttle.go
+++ b/throttle.go
@@ -1,0 +1,105 @@
+package log
+
+import (
+	"sync"
+	"time"
+
+	apex "github.com/eluv-io/apexlog-go"
+	"github.com/eluv-io/utc-go"
+)
+
+type Throttled interface {
+	Trace(msg string, kv ...interface{})
+	Debug(msg string, kv ...interface{})
+	Info(msg string, kv ...interface{})
+	Warn(msg string, kv ...interface{})
+	Error(msg string, kv ...interface{})
+	Fatal(msg string, kv ...interface{})
+}
+
+type throttleFactory struct {
+	mu    sync.Mutex
+	cache map[string]Throttled // throttle key -> Throttled
+}
+
+func (f *throttleFactory) get(logger *apex.Logger, key string, duration ...time.Duration) Throttled {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.cache == nil {
+		f.cache = make(map[string]Throttled)
+	}
+	tl, ok := f.cache[key]
+	if !ok {
+		dur := 5 * time.Second
+		if len(duration) > 0 {
+			dur = duration[0]
+		}
+		tl = newThrottledLog(logger, dur)
+		f.cache[key] = tl
+	}
+	return tl
+}
+
+// newThrottledLog creates a log decorator for throttling similar log entries.
+func newThrottledLog(logger *apex.Logger, period time.Duration) apex.Interface {
+	return &throttledLog{
+		period: period,
+		Logger: logger,
+	}
+}
+
+// newThrottledLog is a log decorator that throttles similar log entries. Similarity is explicitly signalled by the
+// application by specifying a key/value pair in the log statement, where the key corresponds to the configured
+// throttling key and the value matches that of "similar" statements.
+type throttledLog struct {
+	period time.Duration
+	*apex.Logger
+	mu    sync.Mutex
+	count int
+	last  utc.UTC
+}
+
+func (f *throttledLog) Trace(msg string, kv ...any) {
+	f.throttle(f.Logger.Trace, msg, kv...)
+}
+
+func (f *throttledLog) Debug(msg string, kv ...any) {
+	f.throttle(f.Logger.Debug, msg, kv...)
+}
+
+func (f *throttledLog) Info(msg string, kv ...any) {
+	f.throttle(f.Logger.Info, msg, kv...)
+}
+
+func (f *throttledLog) Warn(msg string, kv ...any) {
+	f.throttle(f.Logger.Warn, msg, kv...)
+}
+
+func (f *throttledLog) Error(msg string, kv ...any) {
+	f.throttle(f.Logger.Error, msg, kv...)
+}
+
+func (f *throttledLog) Fatal(msg string, kv ...any) {
+	f.throttle(f.Logger.Fatal, msg, kv...)
+}
+
+func (f *throttledLog) throttle(logFn func(msg string, kv ...any), msg string, kv ...any) {
+	skip := false
+	f.mu.Lock()
+	if f.last.IsZero() {
+		f.last = utc.Now()
+	} else if utc.Since(f.last) >= f.period {
+		kv = append(kv, "suppressed", f.count, "throttle_period", f.period)
+		f.count = 0
+		f.last = utc.Now()
+	} else {
+		f.count++
+		skip = true
+	}
+	f.mu.Unlock()
+	if skip {
+		return
+	}
+	logFn(msg, kv...)
+}


### PR DESCRIPTION
plus
* fix examples for go 1.24 naming convention
* remove conversions between apex.Logger / apex.Entry